### PR TITLE
Improve credential handling

### DIFF
--- a/chancedAPI.py
+++ b/chancedAPI.py
@@ -72,7 +72,7 @@ async def chanced_casino(ctx, driver, channel, credentials):
         # Handle the login logic
         if login_button_present:
             # Use passed credentials or fallback to environment variables if not provided
-            if credentials:
+            if credentials and all(credentials):
                 username, password = credentials
             else:
                 username = os.getenv("CHANCED_USERNAME")

--- a/chumbaAPI.py
+++ b/chumbaAPI.py
@@ -16,8 +16,11 @@ import re
 async def authenticate_chumba(driver, bot, channel):
     try:
         # Load environment variables for login
-        username = os.getenv("CHUMBA").split(":")[0]
-        password = os.getenv("CHUMBA").split(":")[1]
+        creds = os.getenv("CHUMBA")
+        if not creds:
+            await channel.send("CHUMBA credentials not found in environment variables.")
+            return False
+        username, password = creds.split(":")
 
         # Enter login details
         WebDriverWait(driver, 90).until(EC.presence_of_element_located((By.ID, "login_email-input")))

--- a/crowncoinsAPI.py
+++ b/crowncoinsAPI.py
@@ -59,8 +59,11 @@ async def auth_crown_env(driver, bot, ctx, channel):
             login_btn.click()
 
             # If found, proceed with login
-            username = os.getenv("CROWNCOINS").split(":")[0]
-            password = os.getenv("CROWNCOINS").split(":")[1]
+            creds = os.getenv("CROWNCOINS")
+            if not creds:
+                await channel.send("CROWNCOINS credentials not found in environment variables.")
+                return
+            username, password = creds.split(":")
             
             username_field = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located((By.XPATH, "/html/body/div[2]/div[2]/div[2]/div/div/div[1]/div[2]/form/div[1]/input"))

--- a/dingdingdingAPI.py
+++ b/dingdingdingAPI.py
@@ -27,12 +27,16 @@ async def authenticate_dingdingding(driver, bot, ctx, channel):
         email_field = WebDriverWait(driver, 30).until(
             EC.presence_of_element_located((By.XPATH, "/html/body/div[1]/div/div/div[1]/div[1]/div/div/div[2]/form/input[1]"))
         )
-        email_field.send_keys(os.getenv("DINGDINGDING").split(":")[0])
+        creds = os.getenv("DINGDINGDING")
+        if not creds:
+            await channel.send("DINGDINGDING credentials not found in environment variables.")
+            return False
+        email_field.send_keys(creds.split(":")[0])
 
         password_field = WebDriverWait(driver, 30).until(
             EC.presence_of_element_located((By.XPATH, "/html/body/div[1]/div/div/div[1]/div[1]/div/div/div[2]/form/input[2]"))
         )
-        password_field.send_keys(os.getenv("DINGDINGDING").split(":")[1])
+        password_field.send_keys(creds.split(":")[1])
         
         await asyncio.sleep(3)
 

--- a/globalpokerAPI.py
+++ b/globalpokerAPI.py
@@ -45,8 +45,11 @@ async def login_to_global_poker(driver, channel):
                 EC.presence_of_element_located((By.XPATH, "/html/body/main/div/div[2]/form/div/div/div/div/div[2]/div[2]/span/div/div/div/div/div/div/div/div/div[2]/div[3]/div[1]/div/input"))
             )
             # If found, proceed with login
-            username = os.getenv("GLOBAL_POKER").split(":")[0]
-            password = os.getenv("GLOBAL_POKER").split(":")[1]
+            creds = os.getenv("GLOBAL_POKER")
+            if not creds:
+                await channel.send("GLOBAL_POKER credentials not found in environment variables.")
+                return False
+            username, password = creds.split(":")
             
             password_field = WebDriverWait(driver, 10).until(
                 EC.presence_of_element_located((By.XPATH, "/html/body/main/div/div[2]/form/div/div/div/div/div[2]/div[2]/span/div/div/div/div/div/div/div/div/div[2]/div[3]/div[2]/div/div/input"))

--- a/googleauthAPI.py
+++ b/googleauthAPI.py
@@ -20,12 +20,15 @@ load_dotenv()
 # Retrieve the single login string from environment variables
 google_login = os.getenv("GOOGLE_LOGIN")
 
-# Split the login string into email and password
-email, password = google_login.split(":")
+if google_login:
+    # Split the login string into email and password
+    email, password = google_login.split(":")
+else:
+    email = password = None
 
 async def google_auth(ctx, driver, channel, credentials):
     try:
-        if credentials:
+        if credentials and all(credentials):
             username, password = credentials
         else:
             username = os.getenv("GOOGLE_USERNAME")

--- a/luckybirdAPI.py
+++ b/luckybirdAPI.py
@@ -22,11 +22,16 @@ load_dotenv()
 async def authenticate_luckybird(driver, bot, ctx, channel):
     # LuckyBird credentials from the .env file
     try:
-        luckybird_credentials = os.getenv("LUCKYBIRD").split(":")
+        creds = os.getenv("LUCKYBIRD")
+        if not creds:
+            await channel.send("LUCKYBIRD credentials not found in environment variables.")
+            return False
+        luckybird_credentials = creds.split(":")
         username_text = luckybird_credentials[0]
         password_text = luckybird_credentials[1]
-    except:
-        print("LuckyBird credentials not found in environment variables.")
+    except Exception:
+        await channel.send("LUCKYBIRD credentials not found in environment variables.")
+        return False
     try:
         driver.get("https://luckybird.io/")
         # Step 2: Check if login is required

--- a/modoAPI.py
+++ b/modoAPI.py
@@ -28,12 +28,16 @@ async def authenticate_modo(driver, bot, ctx, channel):
             email_field = WebDriverWait(driver, 30).until(
             EC.presence_of_element_located((By.XPATH, "/html/body/main/div/div[2]/form/div/div/div/div/div[2]/div[2]/span/div/div/div/div/div/div/div/div/div[2]/div[3]/div[1]/div/input"))
             )
-            email_field.send_keys(os.getenv("MODO").split(":")[0])
+            creds = os.getenv("MODO")
+            if not creds:
+                await channel.send("MODO credentials not found in environment variables.")
+                return False
+            email_field.send_keys(creds.split(":")[0])
 
             password_field = WebDriverWait(driver, 30).until(
             EC.presence_of_element_located((By.XPATH, "/html/body/main/div/div[2]/form/div/div/div/div/div[2]/div[2]/span/div/div/div/div/div/div/div/div/div[2]/div[3]/div[2]/div/div/input"))
             )
-            password_field.send_keys(os.getenv("MODO").split(":")[1])
+            password_field.send_keys(creds.split(":")[1])
         
             await asyncio.sleep(120)
 

--- a/sportzinoAPI.py
+++ b/sportzinoAPI.py
@@ -113,7 +113,11 @@ async def Sportzino(ctx, driver, channel):
         await asyncio.sleep(5)
         WebDriverWait(driver, 90).until(EC.presence_of_element_located((By.ID, "emailAddress")))
 
-        credentials = os.getenv("SPORTZINO").split(":")
+        creds = os.getenv("SPORTZINO")
+        if not creds:
+            await channel.send("SPORTZINO credentials not found in environment variables.")
+            return
+        credentials = creds.split(":")
         username_text = credentials[0]
         password_text = credentials[1]
 

--- a/zulaAPI.py
+++ b/zulaAPI.py
@@ -109,7 +109,11 @@ async def zula_casino(ctx, driver, channel):
         # Time to wait for the page to fully load before entering username and password
         await asyncio.sleep(5)
         # Retrieve credentials from .env
-        credentials = os.getenv("ZULA").split(":")
+        creds = os.getenv("ZULA")
+        if not creds:
+            await channel.send("ZULA credentials not found in environment variables.")
+            return
+        credentials = creds.split(":")
         username_text = credentials[0]
         password_text = credentials[1]
 


### PR DESCRIPTION
## Summary
- check environment variables before splitting credentials
- return helpful messages when credentials are missing
- safely process `(username, password)` tuples

## Testing
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_6864dacd8c94832b8e702d3157704704