### PR TITLE
Geolocation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,26 +44,26 @@ cd CasinoClaim
 # Supported Casinos ✅
 | Casino         | Auto Claim | Countdown Timer | Backend API | Notes            | Trusted? (payment proof) |
 |----------------|------------|-----------------|-----------------------------|------------------|---------|
-| Chanced        | ✓          | ✓               | No                          | Varies between $.3-$1 SC bonus/day    | Yes     |
-| Global Poker   | ✓          | ✓               | No                          | $0.00-$4 SC bonus/day | Yes     |
-| Rolling Riches | ✓          | ✓               | No                          | $.20 bonus every 6 hours | Yes     |
-| Chumba         | ✓          | ✓               | No                          | $1 bonus/day     | Yes     |
-| DingDingDing   | ✓          | ✓               | No                          | Varies between $0.50 SC and $1 SC | Exit scammed as of 4/2. Do not put your money into DDD. No 🤢     |
-| Stake          | ✗          | ✓               | Yes                         | $1 bonus/day. Auto Claim in development | Yes     |
-| Zula           | ✓          | ✓               | No                          | $1 bonus/day     | Yes     |
-| Fortune Coins  | ✓          | ✗               | No                          | $0.50-$1.20 SC bonus every 24 hours | Yes     |
-| Sportzino      | ✓          | ✓               | No                          | $.50-$1 bonus/day     | Yes     |
-| Luckybird      | ✓          | ✓               | No                          | $.25 bonus/day. Increases with VIP | Yes     |
-| Crown Coins    | ✓          | ✓               | Yes                         | Varies between $0.00-$2 bonus/day. Social Auth support in development | Yes     |
-| Modo           | ✓          | ✓               | No                          | $.30-$1 SC bonus/day | Yes     |
-| Goldnluck      | ✗          | ✗               | No                          | $2 bonus/day     | No 🤢     |
-| Luckyland          | ✗          | ✗               | No                          | $.30-$1 SC bonus/day | Yes     |
-| iCasino          | ✗          | ✗               | No                          | $1.70 SC bonus/day | Yes     |
-| RealPrize         | ✗          | ✗               | No                          | $1.20 SC bonus/day | Yes     |
-| Spin Pals          | ✗          | ✗               | No                          | $1 SC bonus/day | Yes     |
-| Dara Casino          | ✗          | ✗               | No                          | $1 SC bonus/day | Yes     |
-| Pulsz          | IN DEVELOPMENT | IN DEVELOPMENT | IN DEVELOPMENT            | Varies between $.20-$3 SC bonus/day | Yes      |
-
+| Chanced        | ✓          | ✓               | No                          | Varies between $0.30-$1.00 bonus/day    | Yes     |
+| Global Poker   | ✓          | ✓               | No                          | $0.00-$4.00 bonus/day | Yes     |
+| Rolling Riches | ✓          | ✓               | No                          | $0.20 bonus every 6 hours | Yes     |
+| JefeBet        | ✓          | ✓               | No                          | $0.20 bonus every 6 hours | No 🤢 |
+| Chumba         | ✓          | ✓               | No                          | $1.00 bonus/day     | Yes     |
+| Stake          | ✗          | ✓               | Yes                         | $1.00 bonus/day -  Auto Claim in development | Yes     |
+| Zula           | ✓          | ✓               | No                          | $1.00 bonus/day     | Yes     |
+| Fortune Coins  | ✓          | ✗               | No                          | $0.50-$1.20 bonus/day | Yes     |
+| Sportzino      | ✓          | ✓               | No                          | $0.50-$1.00 bonus/day     | Yes     |
+| Luckybird      | ✓          | ✓               | No                          | $0.25 bonus/day -  Increases with VIP | Yes     |
+| Crown Coins    | ✓          | ✓               | Yes                         | Varies between $0.00-$2.00 bonus/day - Social Auth support in development | Yes     |
+| Modo           | ✓          | ✓               | No                          | $0.30-$1.00 bonus/day | Yes     |
+| Goldnluck      | ✗          | ✗               | No                          | $2.00 bonus/day     | No 🤢     |
+| Luckyland      | ✗          | ✗               | No                          | $0.30-$1.00  bonus/day | Yes     |
+| iCasino        | ✗          | ✗               | No                          | $1.70 bonus/day | Yes     |
+| RealPrize      | ✗          | ✗               | No                          | $1.20 bonus/day | Yes     |
+| Spin Pals      | ✗          | ✗               | No                          | $1.00  bonus/day | Yes     |
+| Dara Casino    | ✗          | ✗               | No                          | $1.00  bonus/day | Yes     |
+| Pulsz          | IN DEVELOPMENT | IN DEVELOPMENT | IN DEVELOPMENT            | Varies between $0.20-$3 bonus/day | Yes      |
+| DingDingDing   | ✓          | ✓               | No                          | Varies between $0.50 and $1 SC | Exit scammed as of 4/2/25 - Do not put your money into DDD. No 💩 |
 
 
 # Support 🔮 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,9 @@ cd CasinoClaim
 
 
 
+# Usage 🎰🤖
 
+The bot is designed to run automatically in 2-hour intervals, with commands to check status of bonus. Running `!help` at any time provides the available commands.
 
 
 
@@ -58,12 +60,12 @@ cd CasinoClaim
 | Modo           | ✓          | ✓               | No                          | $0.30-$1.00 bonus/day | Yes     |
 | Goldnluck      | ✗          | ✗               | No                          | $2.00 bonus/day     | No 🤢     |
 | Luckyland      | ✗          | ✗               | No                          | $0.30-$1.00  bonus/day | Yes     |
-| iCasino        | ✗          | ✗               | No                          | $1.70 bonus/day | Yes     |
-| RealPrize      | ✗          | ✗               | No                          | $1.20 bonus/day | Yes     |
-| Spin Pals      | ✗          | ✗               | No                          | $1.00  bonus/day | Yes     |
-| Dara Casino    | ✗          | ✗               | No                          | $1.00  bonus/day | Yes     |
+| iCasino        | IN DEVELOPMENT         | IN DEVELOPMENT               | IN DEVELOPMENT                          | $1.70 bonus/day | Yes     |
+| RealPrize      | IN DEVELOPMENT          | IN DEVELOPMENT               | IN DEVELOPMENT                          | $1.20 bonus/day | Yes     |
+| Spin Pals      | IN DEVELOPMENT          | IN DEVELOPMENT               | IN DEVELOPMENT                          | $1.00  bonus/day | Yes     |
+| Dara Casino    | IN DEVELOPMENT  | IN DEVELOPMENT               | IN DEVELOPMENT                          | $1.00  bonus/day | Yes     |
 | Pulsz          | IN DEVELOPMENT | IN DEVELOPMENT | IN DEVELOPMENT            | Varies between $0.20-$3 bonus/day | Yes      |
-| DingDingDing   | ✓          | ✓               | No                          | Varies between $0.50 and $1 SC | Exit scammed as of 4/2/25 - Do not put your money into DDD. No 💩 |
+| DingDingDing   | ✓          | ✓               | No                          | No SC granted anymore from bonus | Exit scammed as of 4/2/25 - Do not put your money into DDD. No 💩 |
 
 
 # Support 🔮 

--- a/main.py
+++ b/main.py
@@ -81,6 +81,7 @@ user_data_dir = "/temp/google-chrome/"  # Change path for Linux environment
 options.add_argument(f"--user-data-dir={user_data_dir}")
 options.add_extension('/temp/CAPTCHA-Solver-auto-hCAPTCHA-reCAPTCHA-freely-Chrome-Web-Store.crx')
 options.set_capability("goog:loggingPrefs", caps["goog:loggingPrefs"])
+options.add_argument("--allow-geolocation")
 
 # extension = "/root/.config/google-chrome/Default/Extensions"
 


### PR DESCRIPTION
Bot would get stuck on rollingriches due to chrome asking for location access. Enabled geolocation in options argument to always give location.