### PR TITLE
Add captcha helper and use it in Modo auth

### DIFF
--- a/helperAPI.py
+++ b/helperAPI.py
@@ -1,0 +1,25 @@
+# Drake Hooks
+# Casino Claim 2
+# Helper API
+
+"""Utility helpers used across Casino Claim."""
+
+import asyncio
+
+
+async def open_captcha_solver_page(driver):
+    """Open the captcha solver extension page."""
+    try:
+        # Open the extensions page first so the extension context is loaded
+        driver.get("chrome://extensions")
+        await asyncio.sleep(2)
+        # Navigate directly to the captcha solver popup
+        driver.get(
+            "chrome-extension://hlifkpholllijblknnmbfagnkjneagid/popup/popup.html#/"
+        )
+        await asyncio.sleep(5)
+        return True
+    except Exception as e:  # pragma: no cover - best effort
+        print(f"Failed to open captcha solver page: {e}")
+        return False
+


### PR DESCRIPTION
## Summary
- add `helperAPI.py` with a function to open the captcha solver extension
- import and call this helper from `modoAPI.py`
- verify Modo authentication by looking for the `Log Out` button

## Testing
- `python -m py_compile *.py`


------
https://chatgpt.com/codex/tasks/task_e_6883302822f8832ba6083f991c96c41f