### PR TITLE
Switch to uv and remove chumba

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,11 +12,14 @@ RUN apt-get update && apt-get install -y \
     software-properties-common \
     apt-utils \
     ca-certificates \
+    curl \
     python3 \
     python3-venv \
-    python3-pip \
     --no-install-recommends && \
     rm -rf /var/lib/apt/lists/*
+
+# Install uv for managing Python dependencies
+RUN curl -Ls https://astral.sh/uv/install.sh | bash
 
 # Install Chrome
 RUN wget -q -O - https://dl.google.com/linux/linux_signing_key.pub | apt-key add - && \
@@ -36,9 +39,9 @@ COPY ./CAPTCHA-Solver-auto-hCAPTCHA-reCAPTCHA-freely-Chrome-Web-Store.crx /temp/
 # Copy the entire project to /app in the container
 COPY . /app
 
-# Create virtual environment and install Python dependencies
+# Create virtual environment and install Python dependencies using uv
 RUN python3 -m venv /venv && \
-    /venv/bin/pip install --no-cache-dir -r /app/requirements.txt
+    /venv/bin/uv pip install --no-cache-dir -r /app/requirements.txt
 
 # Install common utilities
 RUN apt-get update && apt-get install -y xdg-utils ca-certificates

--- a/main.py
+++ b/main.py
@@ -683,10 +683,6 @@ async def casino_loop():
             await spinpals_flow(None, driver, channel)
         except:
             print("Error in SpinPals")
-        try:
-            await chumba_casino(None, driver, bot)
-        except:
-            print("Error in Chumba")
         await asyncio.sleep(10)
         try:
             await stake_claim(driver, bot, None, channel)


### PR DESCRIPTION
## Summary
- install `uv` instead of `pip` in Dockerfile
- use uv to install Python deps
- drop Chumba from the two-hour casino loop in `main.py`

## Testing
- `python -m py_compile $(git ls-files '*.py') && echo 'compile ok'`
- `pip install -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_68886cb664a4832baa74e124fd9c5751